### PR TITLE
テンプレート設定とテンプレート登録のUI機能実装

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,30 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run Extension",
+            "type": "extensionHost",
+            "request": "launch",
+            "args": [
+                "--extensionDevelopmentPath=${workspaceFolder}"
+            ],
+            "outFiles": [
+                "${workspaceFolder}/out/**/*.js"
+            ],
+            "preLaunchTask": "${defaultBuildTask}"
+        },
+        {
+            "name": "Extension Tests",
+            "type": "extensionHost",
+            "request": "launch",
+            "args": [
+                "--extensionDevelopmentPath=${workspaceFolder}",
+                "--extensionTestsPath=${workspaceFolder}/out/test/suite/index"
+            ],
+            "outFiles": [
+                "${workspaceFolder}/out/test/**/*.js"
+            ],
+            "preLaunchTask": "${defaultBuildTask}"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,18 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "type": "npm",
+            "script": "watch",
+            "problemMatcher": "$tsc-watch",
+            "isBackground": true,
+            "presentation": {
+                "reveal": "never"
+            },
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        }
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,16 @@
       {
         "command": "layered-gen.generateFiles",
         "title": "テンプレートからファイル生成"
+      },
+      {
+        "command": "layered-gen.configureTemplates",
+        "title": "テンプレート設定",
+        "category": "Layered Generator"
+      },
+      {
+        "command": "layered-gen.registerTemplates",
+        "title": "テンプレート登録",
+        "category": "Layered Generator"
       }
     ],
     "menus": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,10 +1,12 @@
 import * as vscode from 'vscode';
 import { TemplateManager } from './templateManager';
+import { TemplateEditorProvider } from './templateEditorProvider';
 
 export function activate(context: vscode.ExtensionContext) {
     console.log('Layered Architecture Generator is now active!');
 
     const templateManager = new TemplateManager();
+    const templateEditorProvider = new TemplateEditorProvider(context, templateManager);
 
     let disposable = vscode.commands.registerCommand('layered-gen.generateFiles', async (uri: vscode.Uri) => {
         if (!uri) {
@@ -57,6 +59,18 @@ export function activate(context: vscode.ExtensionContext) {
     });
 
     context.subscriptions.push(disposable);
+
+    // Register template configuration command
+    let configureTemplatesCommand = vscode.commands.registerCommand('layered-gen.configureTemplates', () => {
+        templateEditorProvider.showTemplateConfiguration();
+    });
+    context.subscriptions.push(configureTemplatesCommand);
+
+    // Register template registration command
+    let registerTemplatesCommand = vscode.commands.registerCommand('layered-gen.registerTemplates', () => {
+        templateEditorProvider.showTemplateRegistration();
+    });
+    context.subscriptions.push(registerTemplatesCommand);
 }
 
 export function deactivate() {}

--- a/src/templateEditorProvider.ts
+++ b/src/templateEditorProvider.ts
@@ -1,0 +1,360 @@
+import * as vscode from 'vscode';
+import { Template, TemplateManager } from './templateManager';
+
+export class TemplateEditorProvider {
+    private _panel: vscode.WebviewPanel | undefined;
+
+    constructor(
+        private readonly context: vscode.ExtensionContext,
+        private readonly templateManager: TemplateManager
+    ) {}
+
+    public showTemplateConfiguration() {
+        if (this._panel) {
+            this._panel.reveal();
+        } else {
+            this._panel = vscode.window.createWebviewPanel(
+                'templateConfiguration',
+                'テンプレート設定',
+                vscode.ViewColumn.One,
+                {
+                    enableScripts: true,
+                    retainContextWhenHidden: true
+                }
+            );
+
+            this._panel.webview.html = this.getTemplateConfigurationHtml();
+            this._panel.webview.onDidReceiveMessage(
+                message => this.handleMessage(message, 'configuration'),
+                undefined,
+                this.context.subscriptions
+            );
+
+            this._panel.onDidDispose(() => {
+                this._panel = undefined;
+            });
+        }
+    }
+
+    public showTemplateRegistration() {
+        if (this._panel) {
+            this._panel.reveal();
+        } else {
+            this._panel = vscode.window.createWebviewPanel(
+                'templateRegistration',
+                'テンプレート登録',
+                vscode.ViewColumn.One,
+                {
+                    enableScripts: true,
+                    retainContextWhenHidden: true
+                }
+            );
+
+            this._panel.webview.html = this.getTemplateRegistrationHtml();
+            this._panel.webview.onDidReceiveMessage(
+                message => this.handleMessage(message, 'registration'),
+                undefined,
+                this.context.subscriptions
+            );
+
+            this._panel.onDidDispose(() => {
+                this._panel = undefined;
+            });
+        }
+    }
+
+    private async handleMessage(message: any, type: 'configuration' | 'registration') {
+        const config = vscode.workspace.getConfiguration('layered-gen');
+        
+        switch (message.command) {
+            case 'saveTemplates':
+                await config.update('templates', message.templates, vscode.ConfigurationTarget.Global);
+                vscode.window.showInformationMessage('テンプレート構成を保存しました');
+                break;
+            
+            case 'saveFileTemplates':
+                await config.update('fileTemplates', message.fileTemplates, vscode.ConfigurationTarget.Global);
+                vscode.window.showInformationMessage('ファイルテンプレートを保存しました');
+                break;
+            
+            case 'getTemplates':
+                const templates = config.get<Template[]>('templates') || [];
+                this._panel?.webview.postMessage({ command: 'loadTemplates', templates });
+                break;
+            
+            case 'getFileTemplates':
+                const fileTemplates = config.get<{ [key: string]: string }>('fileTemplates') || {};
+                this._panel?.webview.postMessage({ command: 'loadFileTemplates', fileTemplates });
+                break;
+        }
+    }
+
+    private getTemplateConfigurationHtml(): string {
+        return `
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>テンプレート設定</title>
+    <style>
+        body {
+            font-family: var(--vscode-font-family);
+            color: var(--vscode-foreground);
+            background-color: var(--vscode-editor-background);
+            padding: 20px;
+        }
+        .template-item {
+            border: 1px solid var(--vscode-panel-border);
+            padding: 15px;
+            margin-bottom: 15px;
+            border-radius: 5px;
+        }
+        .structure-item {
+            display: flex;
+            gap: 10px;
+            margin-bottom: 10px;
+        }
+        input, select {
+            background-color: var(--vscode-input-background);
+            color: var(--vscode-input-foreground);
+            border: 1px solid var(--vscode-input-border);
+            padding: 5px;
+            border-radius: 3px;
+        }
+        button {
+            background-color: var(--vscode-button-background);
+            color: var(--vscode-button-foreground);
+            border: none;
+            padding: 8px 15px;
+            border-radius: 3px;
+            cursor: pointer;
+            margin-right: 10px;
+        }
+        button:hover {
+            background-color: var(--vscode-button-hoverBackground);
+        }
+        .remove-btn {
+            background-color: var(--vscode-inputValidation-errorBackground);
+        }
+        h2 {
+            margin-top: 30px;
+        }
+    </style>
+</head>
+<body>
+    <h1>テンプレート設定</h1>
+    <p>ファイル生成時のディレクトリ構造とファイル名のパターンを設定します。</p>
+    
+    <div id="templates"></div>
+    
+    <button onclick="addTemplate()">新しいテンプレートを追加</button>
+    <button onclick="saveTemplates()">保存</button>
+
+    <script>
+        const vscode = acquireVsCodeApi();
+        let templates = [];
+
+        window.addEventListener('message', event => {
+            const message = event.data;
+            if (message.command === 'loadTemplates') {
+                templates = message.templates;
+                renderTemplates();
+            }
+        });
+
+        function renderTemplates() {
+            const container = document.getElementById('templates');
+            container.innerHTML = templates.map((template, index) => \`
+                <div class="template-item">
+                    <h3>テンプレート名: <input type="text" value="\${template.name}" onchange="updateTemplateName(\${index}, this.value)" /></h3>
+                    <div id="structure-\${index}">
+                        \${template.structure.map((item, itemIndex) => \`
+                            <div class="structure-item">
+                                <input type="text" placeholder="パス (例: domain/{name}.ts)" value="\${item.path}" onchange="updateStructurePath(\${index}, \${itemIndex}, this.value)" style="flex: 2" />
+                                <input type="text" placeholder="テンプレートID" value="\${item.template}" onchange="updateStructureTemplate(\${index}, \${itemIndex}, this.value)" style="flex: 1" />
+                                <button class="remove-btn" onclick="removeStructureItem(\${index}, \${itemIndex})">削除</button>
+                            </div>
+                        \`).join('')}
+                    </div>
+                    <button onclick="addStructureItem(\${index})">構造を追加</button>
+                    <button class="remove-btn" onclick="removeTemplate(\${index})">テンプレートを削除</button>
+                </div>
+            \`).join('');
+        }
+
+        function updateTemplateName(index, value) {
+            templates[index].name = value;
+        }
+
+        function updateStructurePath(templateIndex, itemIndex, value) {
+            templates[templateIndex].structure[itemIndex].path = value;
+        }
+
+        function updateStructureTemplate(templateIndex, itemIndex, value) {
+            templates[templateIndex].structure[itemIndex].template = value;
+        }
+
+        function addStructureItem(templateIndex) {
+            templates[templateIndex].structure.push({ path: '', template: '' });
+            renderTemplates();
+        }
+
+        function removeStructureItem(templateIndex, itemIndex) {
+            templates[templateIndex].structure.splice(itemIndex, 1);
+            renderTemplates();
+        }
+
+        function addTemplate() {
+            templates.push({
+                name: '新しいテンプレート',
+                structure: [{ path: '', template: '' }]
+            });
+            renderTemplates();
+        }
+
+        function removeTemplate(index) {
+            templates.splice(index, 1);
+            renderTemplates();
+        }
+
+        function saveTemplates() {
+            vscode.postMessage({ command: 'saveTemplates', templates });
+        }
+
+        // Load initial data
+        vscode.postMessage({ command: 'getTemplates' });
+    </script>
+</body>
+</html>
+        `;
+    }
+
+    private getTemplateRegistrationHtml(): string {
+        return `
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>テンプレート登録</title>
+    <style>
+        body {
+            font-family: var(--vscode-font-family);
+            color: var(--vscode-foreground);
+            background-color: var(--vscode-editor-background);
+            padding: 20px;
+        }
+        .template-item {
+            margin-bottom: 30px;
+        }
+        textarea {
+            width: 100%;
+            min-height: 200px;
+            background-color: var(--vscode-input-background);
+            color: var(--vscode-input-foreground);
+            border: 1px solid var(--vscode-input-border);
+            padding: 10px;
+            border-radius: 3px;
+            font-family: var(--vscode-editor-font-family);
+            font-size: var(--vscode-editor-font-size);
+        }
+        button {
+            background-color: var(--vscode-button-background);
+            color: var(--vscode-button-foreground);
+            border: none;
+            padding: 8px 15px;
+            border-radius: 3px;
+            cursor: pointer;
+            margin-right: 10px;
+        }
+        button:hover {
+            background-color: var(--vscode-button-hoverBackground);
+        }
+        .placeholder-info {
+            background-color: var(--vscode-textBlockQuote-background);
+            padding: 10px;
+            border-radius: 3px;
+            margin-bottom: 20px;
+        }
+        code {
+            background-color: var(--vscode-textCodeBlock-background);
+            padding: 2px 4px;
+            border-radius: 3px;
+        }
+    </style>
+</head>
+<body>
+    <h1>テンプレート登録</h1>
+    
+    <div class="placeholder-info">
+        <h3>利用可能なプレースホルダー:</h3>
+        <ul>
+            <li><code>{Name}</code> - PascalCase形式の名前 (例: UserProfile)</li>
+            <li><code>{name}</code> - camelCase形式の名前 (例: userProfile)</li>
+        </ul>
+    </div>
+
+    <div id="fileTemplates"></div>
+    
+    <button onclick="addFileTemplate()">新しいファイルテンプレートを追加</button>
+    <button onclick="saveFileTemplates()">保存</button>
+
+    <script>
+        const vscode = acquireVsCodeApi();
+        let fileTemplates = {};
+
+        window.addEventListener('message', event => {
+            const message = event.data;
+            if (message.command === 'loadFileTemplates') {
+                fileTemplates = message.fileTemplates;
+                renderFileTemplates();
+            }
+        });
+
+        function renderFileTemplates() {
+            const container = document.getElementById('fileTemplates');
+            container.innerHTML = Object.entries(fileTemplates).map(([key, value]) => \`
+                <div class="template-item">
+                    <h3>テンプレートID: <input type="text" value="\${key}" onchange="updateTemplateKey('\${key}', this.value)" /></h3>
+                    <textarea onchange="updateTemplateContent('\${key}', this.value)">\${value}</textarea>
+                    <button onclick="removeFileTemplate('\${key}')">削除</button>
+                </div>
+            \`).join('');
+        }
+
+        function updateTemplateKey(oldKey, newKey) {
+            if (oldKey !== newKey) {
+                fileTemplates[newKey] = fileTemplates[oldKey];
+                delete fileTemplates[oldKey];
+                renderFileTemplates();
+            }
+        }
+
+        function updateTemplateContent(key, value) {
+            fileTemplates[key] = value;
+        }
+
+        function addFileTemplate() {
+            const newKey = 'newTemplate' + Object.keys(fileTemplates).length;
+            fileTemplates[newKey] = '// 新しいテンプレート\\nexport class {Name} {\\n  // TODO: Implement\\n}\\n';
+            renderFileTemplates();
+        }
+
+        function removeFileTemplate(key) {
+            delete fileTemplates[key];
+            renderFileTemplates();
+        }
+
+        function saveFileTemplates() {
+            vscode.postMessage({ command: 'saveFileTemplates', fileTemplates });
+        }
+
+        // Load initial data
+        vscode.postMessage({ command: 'getFileTemplates' });
+    </script>
+</body>
+</html>
+        `;
+    }
+}

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -12,4 +12,14 @@ suite('Extension Test Suite', () => {
         const commands = await vscode.commands.getCommands();
         assert.ok(commands.includes('layered-gen.generateFiles'));
     });
+
+    test('Should register configure templates command', async () => {
+        const commands = await vscode.commands.getCommands();
+        assert.ok(commands.includes('layered-gen.configureTemplates'));
+    });
+
+    test('Should register register templates command', async () => {
+        const commands = await vscode.commands.getCommands();
+        assert.ok(commands.includes('layered-gen.registerTemplates'));
+    });
 });

--- a/src/test/suite/templateEditorProvider.test.ts
+++ b/src/test/suite/templateEditorProvider.test.ts
@@ -1,0 +1,32 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { TemplateEditorProvider } from '../../templateEditorProvider';
+import { TemplateManager } from '../../templateManager';
+
+suite('TemplateEditorProvider Test Suite', () => {
+    let context: vscode.ExtensionContext;
+    let templateManager: TemplateManager;
+    let templateEditorProvider: TemplateEditorProvider;
+
+    setup(() => {
+        // Mock extension context
+        context = {
+            subscriptions: []
+        } as any;
+        
+        templateManager = new TemplateManager();
+        templateEditorProvider = new TemplateEditorProvider(context, templateManager);
+    });
+
+    test('Should create template editor provider instance', () => {
+        assert.ok(templateEditorProvider);
+    });
+
+    test('Should have showTemplateConfiguration method', () => {
+        assert.ok(typeof templateEditorProvider.showTemplateConfiguration === 'function');
+    });
+
+    test('Should have showTemplateRegistration method', () => {
+        assert.ok(typeof templateEditorProvider.showTemplateRegistration === 'function');
+    });
+});


### PR DESCRIPTION
Closes #3

## Summary
- テンプレート設定UI: Webviewを使用してテンプレート構成（ディレクトリ・ファイル構造）を視覚的に編集可能
- テンプレート登録UI: 各ファイルテンプレートの内容を編集・管理するためのインターフェース
- VSCodeの設定への保存・読み込み機能

## 実装内容
- `layered-gen.configureTemplates`コマンド: テンプレート構成を編集するためのWebview UI
- `layered-gen.registerTemplates`コマンド: ファイルテンプレートの内容を編集するためのWebview UI
- TemplateEditorProviderクラス: Webviewの管理と設定の保存・読み込み処理
- 動的なテンプレート追加・削除・編集機能
- プレースホルダー（{Name}、{name}）のサポート

## Test plan
- [x] 拡張機能のコンパイル確認
- [x] ESLintによるコード品質チェック
- [x] ユニットテストの作成と実行
- [ ] VSCode上での動作確認
- [ ] テンプレート設定UIでのテンプレート編集確認
- [ ] テンプレート登録UIでのファイル内容編集確認
- [ ] 設定の保存と読み込み確認

🤖 Generated with [Claude Code](https://claude.ai/code)