### PR TITLE
ProtoBuf（.proto）ファイル内の記述に連番をつける機能

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,11 @@
         "command": "layered-gen.registerTemplates",
         "title": "テンプレート登録",
         "category": "Layered Generator"
+      },
+      {
+        "command": "layered-gen.numberProtobufFields",
+        "title": "Protobufフィールドに連番を付ける",
+        "category": "Layered Generator"
       }
     ],
     "menus": {

--- a/samples/example.proto
+++ b/samples/example.proto
@@ -1,0 +1,40 @@
+syntax = "proto3";
+
+package example;
+
+// Example message with unordered field numbers
+message User {
+    string id = 10;
+    string name = 2;
+    int32 age = 5;
+    repeated string emails = 1;
+    bool is_active = 8;
+}
+
+// Nested message example
+message Order {
+    string order_id = 3;
+    User customer = 1;
+    repeated Item items = 5;
+    double total_price = 2;
+    
+    message Item {
+        string product_id = 2;
+        int32 quantity = 1;
+        double price = 3;
+    }
+}
+
+// Empty message
+message Empty {
+}
+
+// Message with reserved fields
+message WithReserved {
+    reserved 2, 15, 9 to 11;
+    reserved "foo", "bar";
+    
+    string field1 = 1;
+    string field2 = 5;
+    string field3 = 3;
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,12 +1,14 @@
 import * as vscode from 'vscode';
 import { TemplateManager } from './templateManager';
 import { TemplateEditorProvider } from './templateEditorProvider';
+import { ProtobufFieldNumberer } from './protobufFieldNumberer';
 
 export function activate(context: vscode.ExtensionContext) {
     console.log('Layered Architecture Generator is now active!');
 
     const templateManager = new TemplateManager();
     const templateEditorProvider = new TemplateEditorProvider(context, templateManager);
+    const protobufFieldNumberer = new ProtobufFieldNumberer();
 
     let disposable = vscode.commands.registerCommand('layered-gen.generateFiles', async (uri: vscode.Uri) => {
         if (!uri) {
@@ -79,6 +81,16 @@ export function activate(context: vscode.ExtensionContext) {
         }
     });
     context.subscriptions.push(registerTemplatesCommand);
+
+    // Register protobuf field numbering command
+    let numberProtobufFieldsCommand = vscode.commands.registerCommand('layered-gen.numberProtobufFields', async () => {
+        try {
+            await protobufFieldNumberer.numberFields();
+        } catch (error) {
+            vscode.window.showErrorMessage(`Protobufフィールド番号付けエラー: ${error}`);
+        }
+    });
+    context.subscriptions.push(numberProtobufFieldsCommand);
 }
 
 export function deactivate() {}

--- a/src/protobufFieldNumberer.ts
+++ b/src/protobufFieldNumberer.ts
@@ -1,0 +1,117 @@
+import * as vscode from 'vscode';
+
+export class ProtobufFieldNumberer {
+    
+    public async numberFields() {
+        const editor = vscode.window.activeTextEditor;
+        
+        if (!editor) {
+            vscode.window.showErrorMessage('アクティブなエディタがありません');
+            return;
+        }
+        
+        const document = editor.document;
+        
+        // Check if the file is a .proto file
+        if (!document.fileName.endsWith('.proto')) {
+            vscode.window.showErrorMessage('.protoファイルを開いてください');
+            return;
+        }
+        
+        const text = document.getText();
+        const lines = text.split('\n');
+        
+        // Find all message blocks
+        const messageBlocks = this.findMessageBlocks(lines);
+        
+        if (messageBlocks.length === 0) {
+            vscode.window.showInformationMessage('messageブロックが見つかりませんでした');
+            return;
+        }
+        
+        // Apply edits
+        await editor.edit(editBuilder => {
+            for (const block of messageBlocks) {
+                this.numberFieldsInBlock(lines, block, editBuilder, document);
+            }
+        });
+        
+        vscode.window.showInformationMessage('フィールド番号を更新しました');
+    }
+    
+    private findMessageBlocks(lines: string[]): Array<{start: number, end: number, depth: number}> {
+        const blocks: Array<{start: number, end: number, depth: number}> = [];
+        const stack: Array<{start: number, depth: number}> = [];
+        let depth = 0;
+        
+        for (let i = 0; i < lines.length; i++) {
+            const line = lines[i].trim();
+            
+            // Check for message start
+            if (line.match(/^message\s+\w+\s*{/) || line.match(/^\s*message\s+\w+\s*{/)) {
+                stack.push({ start: i, depth: depth });
+                depth++;
+            } else if (line.includes('{')) {
+                // Other types of blocks (enum, oneof, etc.)
+                depth++;
+            }
+            
+            // Check for closing brace
+            if (line.includes('}')) {
+                depth--;
+                // Check if this closes a message block
+                if (stack.length > 0 && depth === stack[stack.length - 1].depth) {
+                    const messageStart = stack.pop()!;
+                    blocks.push({
+                        start: messageStart.start,
+                        end: i,
+                        depth: messageStart.depth
+                    });
+                }
+            }
+        }
+        
+        // Sort blocks by start line to process them in order
+        return blocks.sort((a, b) => a.start - b.start);
+    }
+    
+    private numberFieldsInBlock(
+        lines: string[], 
+        block: {start: number, end: number, depth?: number}, 
+        editBuilder: vscode.TextEditorEdit,
+        document: vscode.TextDocument
+    ) {
+        let fieldNumber = 1;
+        const fieldRegex = /^(\s*)(optional\s+|required\s+|repeated\s+)?(\w+)\s+(\w+)\s*=\s*(\d+)?\s*;/;
+        
+        for (let i = block.start + 1; i < block.end; i++) {
+            const line = lines[i];
+            const match = line.match(fieldRegex);
+            
+            if (match) {
+                const indent = match[1];
+                const modifier = match[2] || '';
+                const type = match[3];
+                const name = match[4];
+                const existingNumber = match[5];
+                
+                // Skip if it's a reserved field
+                if (line.trim().startsWith('reserved')) {
+                    continue;
+                }
+                
+                // Create new line with sequential number
+                const newLine = `${indent}${modifier}${type} ${name} = ${fieldNumber};`;
+                
+                // Replace the entire line
+                const lineRange = new vscode.Range(
+                    new vscode.Position(i, 0),
+                    new vscode.Position(i, line.length)
+                );
+                
+                editBuilder.replace(lineRange, newLine);
+                fieldNumber++;
+            }
+        }
+    }
+}

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -22,4 +22,9 @@ suite('Extension Test Suite', () => {
         const commands = await vscode.commands.getCommands();
         assert.ok(commands.includes('layered-gen.registerTemplates'));
     });
+
+    test('Should register number protobuf fields command', async () => {
+        const commands = await vscode.commands.getCommands();
+        assert.ok(commands.includes('layered-gen.numberProtobufFields'));
+    });
 });

--- a/src/test/suite/protobufFieldNumberer.test.ts
+++ b/src/test/suite/protobufFieldNumberer.test.ts
@@ -1,0 +1,97 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { ProtobufFieldNumberer } from '../../protobufFieldNumberer';
+import * as path from 'path';
+import * as fs from 'fs';
+
+suite('ProtobufFieldNumberer Test Suite', () => {
+    let protobufFieldNumberer: ProtobufFieldNumberer;
+    const testWorkspace = path.join(__dirname, 'test-workspace');
+    const testProtoFile = path.join(testWorkspace, 'test.proto');
+
+    setup(() => {
+        protobufFieldNumberer = new ProtobufFieldNumberer();
+        
+        // Create test workspace directory
+        if (!fs.existsSync(testWorkspace)) {
+            fs.mkdirSync(testWorkspace, { recursive: true });
+        }
+    });
+
+    teardown(() => {
+        // Clean up test workspace
+        if (fs.existsSync(testWorkspace)) {
+            fs.rmSync(testWorkspace, { recursive: true, force: true });
+        }
+    });
+
+    test('Should create protobuf field numberer instance', () => {
+        assert.ok(protobufFieldNumberer);
+    });
+
+    test('Should show error when no active editor', async () => {
+        // Close all editors
+        await vscode.commands.executeCommand('workbench.action.closeAllEditors');
+        
+        // This test would need to mock vscode.window.showErrorMessage
+        // to verify the error message is shown
+    });
+
+    test('Should show error for non-.proto files', async () => {
+        // Create a non-proto file
+        const nonProtoFile = path.join(testWorkspace, 'test.txt');
+        fs.writeFileSync(nonProtoFile, 'not a proto file');
+        
+        // Open the file
+        const doc = await vscode.workspace.openTextDocument(nonProtoFile);
+        await vscode.window.showTextDocument(doc);
+        
+        // Execute command - should show error
+        await protobufFieldNumberer.numberFields();
+        
+        // Close the editor
+        await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
+    });
+
+    test('Should number fields in proto file', async () => {
+        // Create a test proto file
+        const protoContent = `syntax = "proto3";
+
+message User {
+    string name = 10;
+    int32 age = 5;
+    repeated string emails = 1;
+}
+
+message Product {
+    string id = 2;
+    string title = 1;
+    double price = 3;
+}`;
+        
+        fs.writeFileSync(testProtoFile, protoContent);
+        
+        // Open the file
+        const doc = await vscode.workspace.openTextDocument(testProtoFile);
+        const editor = await vscode.window.showTextDocument(doc);
+        
+        // Execute numbering
+        await protobufFieldNumberer.numberFields();
+        
+        // Check the result
+        const updatedContent = doc.getText();
+        
+        // Verify User message fields are numbered 1, 2, 3
+        assert.ok(updatedContent.includes('string name = 1;'));
+        assert.ok(updatedContent.includes('int32 age = 2;'));
+        assert.ok(updatedContent.includes('repeated string emails = 3;'));
+        
+        // Verify Product message fields are numbered 1, 2, 3
+        assert.ok(updatedContent.match(/Product[\s\S]*?string id = 1;/));
+        assert.ok(updatedContent.match(/Product[\s\S]*?string title = 2;/));
+        assert.ok(updatedContent.match(/Product[\s\S]*?double price = 3;/));
+        
+        // Close the editor
+        await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
+    });
+});


### PR DESCRIPTION
Closes #5

## Summary
- 現在開いている.protoファイル内のmessageフィールドに自動で連番を付ける機能を実装
- コマンドパレットから「Layered Generator: Protobufフィールドに連番を付ける」を実行
- .protoファイル以外が開かれている場合はエラーメッセージを表示

## 実装内容
- `layered-gen.numberProtobufFields`コマンドを追加
- ProtobufFieldNumbererクラスを実装
  - messageブロックの検出と解析
  - ネストされたmessageにも対応
  - 各messageブロック内でフィールドに1から順番に番号を振る
  - reserved フィールドはスキップ
  - optional/required/repeatedなどの修飾子を保持

## Test plan
- [x] 拡張機能のコンパイル確認
- [x] ESLintによるコード品質チェック
- [x] ユニットテストの作成と実行
- [ ] VSCode上での動作確認
- [ ] サンプルファイル（samples/example.proto）での動作確認
- [ ] エラーケースの確認（非.protoファイル）

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a command to automatically assign sequential numbers to fields in Protocol Buffers (`.proto`) message definitions within the editor.
- **Tests**
  - Introduced comprehensive tests to ensure correct numbering of fields and command registration.
- **Chores**
  - Added a sample `.proto` file demonstrating various message structures and reserved fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->