### PR TITLE
feat: 依存グラフ描画の除外パターン (.depgraphignore) 対応

### DIFF
--- a/.depgraphignore
+++ b/.depgraphignore
@@ -1,0 +1,34 @@
+# Test files
+**/*.spec.ts
+**/*.spec.tsx
+**/*.spec.js
+**/*.spec.jsx
+**/*.test.ts
+**/*.test.tsx
+**/*.test.js
+**/*.test.jsx
+
+# Test directories
+**/tests/**
+**/test/**
+**/__tests__/**
+**/__mocks__/**
+
+# Build output
+**/dist/**
+**/out/**
+**/build/**
+**/coverage/**
+
+# Dependencies
+**/node_modules/**
+
+# Temp files
+**/temp/**
+**/tmp/**
+**/*.log
+**/.DS_Store
+
+# IDE files
+**/.vscode/**
+**/.idea/**

--- a/package.json
+++ b/package.json
@@ -138,6 +138,14 @@
           "type": "string",
           "default": "30s",
           "description": "k6ロードテストの実行時間"
+        },
+        "depGraph.exclude": {
+          "type": "array",
+          "default": [],
+          "description": "依存グラフから除外するファイルパターン（glob形式）",
+          "items": {
+            "type": "string"
+          }
         }
       }
     }

--- a/src/dependencyGraphAnalyzer.ts
+++ b/src/dependencyGraphAnalyzer.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import globby from 'globby';
 import { Project, SourceFile, SyntaxKind } from 'ts-morph';
 import * as path from 'path';
+import { IgnorePatternUtils } from './ignorePatternUtils';
 
 export interface DependencyNode {
     id: string;
@@ -72,12 +73,7 @@ export class DependencyGraphAnalyzer {
             });
         }
 
-        const excludePatterns = [
-            '**/node_modules/**',
-            '**/out/**',
-            '**/dist/**',
-            '**/*.d.ts'
-        ];
+        const excludePatterns = await IgnorePatternUtils.getExcludePatterns(this.workspaceRoot);
 
         console.log('Collecting files with patterns:', patterns);
         console.log('Workspace root:', this.workspaceRoot);
@@ -86,7 +82,7 @@ export class DependencyGraphAnalyzer {
         const files = await globby(patterns, {
             cwd: this.workspaceRoot,
             ignore: excludePatterns,
-            gitignore: true,
+            gitignore: false, // We handle gitignore ourselves through IgnorePatternUtils
             absolute: true
         });
 

--- a/src/ignorePatternUtils.ts
+++ b/src/ignorePatternUtils.ts
@@ -1,0 +1,136 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+export class IgnorePatternUtils {
+    private static readonly defaultPatterns = [
+        '**/node_modules/**',
+        '**/out/**',
+        '**/dist/**',
+        '**/*.d.ts',
+        '**/coverage/**',
+        '**/*.spec.ts',
+        '**/*.spec.tsx',
+        '**/*.spec.js',
+        '**/*.spec.jsx',
+        '**/*.test.ts',
+        '**/*.test.tsx',
+        '**/*.test.js',
+        '**/*.test.jsx',
+        '**/tests/**',
+        '**/test/**',
+        '**/__tests__/**',
+        '**/__mocks__/**',
+        '**/.git/**',
+        '**/.vscode/**',
+        '**/.idea/**',
+        '**/build/**',
+        '**/temp/**',
+        '**/tmp/**',
+        '**/*.log',
+        '**/.DS_Store'
+    ];
+
+    static async getExcludePatterns(workspaceRoot: string): Promise<string[]> {
+        // Priority 1: VSCode settings
+        const config = vscode.workspace.getConfiguration('depGraph');
+        const settingsPatterns = config.get<string[]>('exclude');
+        if (settingsPatterns && settingsPatterns.length > 0) {
+            return this.processPatterns(settingsPatterns);
+        }
+
+        // Priority 2: .depgraphignore file
+        const depgraphIgnorePath = path.join(workspaceRoot, '.depgraphignore');
+        if (fs.existsSync(depgraphIgnorePath)) {
+            try {
+                const patterns = await this.parseIgnoreFile(depgraphIgnorePath);
+                if (patterns.length > 0) {
+                    return patterns;
+                }
+            } catch (error) {
+                console.warn('Failed to parse .depgraphignore:', error);
+            }
+        }
+
+        // Priority 3: .gitignore file
+        const gitignorePath = path.join(workspaceRoot, '.gitignore');
+        if (fs.existsSync(gitignorePath)) {
+            try {
+                const patterns = await this.parseIgnoreFile(gitignorePath);
+                if (patterns.length > 0) {
+                    return patterns;
+                }
+            } catch (error) {
+                console.warn('Failed to parse .gitignore:', error);
+            }
+        }
+
+        // Priority 4: Default patterns
+        return this.defaultPatterns;
+    }
+
+    private static async parseIgnoreFile(filePath: string): Promise<string[]> {
+        const content = await fs.promises.readFile(filePath, 'utf-8');
+        const lines = content.split('\n');
+        const patterns: string[] = [];
+        const negatedPatterns: string[] = [];
+
+        for (const line of lines) {
+            const trimmed = line.trim();
+            
+            // Skip empty lines and comments
+            if (!trimmed || trimmed.startsWith('#')) {
+                continue;
+            }
+
+            // Handle negation patterns
+            if (trimmed.startsWith('!')) {
+                negatedPatterns.push(trimmed.substring(1));
+                continue;
+            }
+
+            // Convert directory patterns to glob patterns
+            let pattern = trimmed;
+            if (pattern.endsWith('/')) {
+                pattern = pattern + '**';
+            }
+
+            // Ensure patterns are properly formatted for globby
+            if (!pattern.startsWith('**/') && !pattern.startsWith('/')) {
+                pattern = '**/' + pattern;
+            }
+
+            patterns.push(pattern);
+        }
+
+        // Apply negated patterns
+        const finalPatterns = patterns.filter(pattern => {
+            for (const negated of negatedPatterns) {
+                if (pattern === negated || pattern === '**/' + negated) {
+                    return false;
+                }
+            }
+            return true;
+        });
+
+        return finalPatterns;
+    }
+
+    private static processPatterns(patterns: string[]): string[] {
+        return patterns.map(pattern => {
+            let processed = pattern.trim();
+            
+            // Convert directory patterns to glob patterns
+            if (processed.endsWith('/')) {
+                processed = processed + '**';
+            }
+
+            // Ensure patterns are properly formatted for globby
+            if (!processed.startsWith('**/') && !processed.startsWith('/') && !processed.includes('*')) {
+                processed = '**/' + processed;
+            }
+
+            return processed;
+        });
+    }
+}

--- a/src/test/suite/ignorePatternUtils.test.ts
+++ b/src/test/suite/ignorePatternUtils.test.ts
@@ -1,0 +1,206 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import * as path from 'path';
+import * as fs from 'fs';
+import { IgnorePatternUtils } from '../../ignorePatternUtils';
+
+suite('IgnorePatternUtils Test Suite', () => {
+    let testWorkspaceDir: string;
+    
+    suiteSetup(async () => {
+        const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+        if (!workspaceFolder) {
+            throw new Error('No workspace folder found');
+        }
+        testWorkspaceDir = workspaceFolder.uri.fsPath;
+    });
+
+    suiteTeardown(async () => {
+        // Clean up test files
+        const filesToClean = ['.depgraphignore', '.gitignore'];
+        for (const file of filesToClean) {
+            const filePath = path.join(testWorkspaceDir, file);
+            if (fs.existsSync(filePath)) {
+                fs.unlinkSync(filePath);
+            }
+        }
+        
+        // Reset VSCode settings
+        const config = vscode.workspace.getConfiguration('depGraph');
+        await config.update('exclude', undefined, vscode.ConfigurationTarget.Workspace);
+    });
+
+    test('Should use VSCode settings when available', async () => {
+        // Set VSCode settings
+        const config = vscode.workspace.getConfiguration('depGraph');
+        const testPatterns = ['**/*.spec.ts', 'test/**', 'mock/**'];
+        await config.update('exclude', testPatterns, vscode.ConfigurationTarget.Workspace);
+
+        const patterns = await IgnorePatternUtils.getExcludePatterns(testWorkspaceDir);
+        
+        assert.deepStrictEqual(patterns, testPatterns);
+    });
+
+    test('Should parse .depgraphignore file correctly', async () => {
+        // Reset VSCode settings
+        const config = vscode.workspace.getConfiguration('depGraph');
+        await config.update('exclude', undefined, vscode.ConfigurationTarget.Workspace);
+
+        // Create .depgraphignore file
+        const depgraphIgnorePath = path.join(testWorkspaceDir, '.depgraphignore');
+        const content = `
+# Comment line
+node_modules/
+dist/
+*.spec.ts
+test/**
+
+# Negation pattern
+!test/important.ts
+`;
+        fs.writeFileSync(depgraphIgnorePath, content);
+
+        const patterns = await IgnorePatternUtils.getExcludePatterns(testWorkspaceDir);
+        
+        assert.ok(patterns.includes('**/node_modules/**'));
+        assert.ok(patterns.includes('**/dist/**'));
+        assert.ok(patterns.includes('**/*.spec.ts'));
+        assert.ok(patterns.includes('**/test/**'));
+        assert.ok(!patterns.includes('**/test/important.ts'));
+    });
+
+    test('Should fallback to .gitignore when .depgraphignore does not exist', async () => {
+        // Reset VSCode settings
+        const config = vscode.workspace.getConfiguration('depGraph');
+        await config.update('exclude', undefined, vscode.ConfigurationTarget.Workspace);
+
+        // Ensure .depgraphignore does not exist
+        const depgraphIgnorePath = path.join(testWorkspaceDir, '.depgraphignore');
+        if (fs.existsSync(depgraphIgnorePath)) {
+            fs.unlinkSync(depgraphIgnorePath);
+        }
+
+        // Create .gitignore file
+        const gitignorePath = path.join(testWorkspaceDir, '.gitignore');
+        const content = `
+node_modules
+build/
+*.log
+.env
+`;
+        fs.writeFileSync(gitignorePath, content);
+
+        const patterns = await IgnorePatternUtils.getExcludePatterns(testWorkspaceDir);
+        
+        assert.ok(patterns.includes('**/node_modules'));
+        assert.ok(patterns.includes('**/build/**'));
+        assert.ok(patterns.includes('**/*.log'));
+        assert.ok(patterns.includes('**/.env'));
+    });
+
+    test('Should use default patterns when no ignore files exist', async () => {
+        // Reset VSCode settings
+        const config = vscode.workspace.getConfiguration('depGraph');
+        await config.update('exclude', undefined, vscode.ConfigurationTarget.Workspace);
+
+        // Ensure ignore files don't exist
+        const depgraphIgnorePath = path.join(testWorkspaceDir, '.depgraphignore');
+        const gitignorePath = path.join(testWorkspaceDir, '.gitignore');
+        
+        if (fs.existsSync(depgraphIgnorePath)) {
+            fs.unlinkSync(depgraphIgnorePath);
+        }
+        if (fs.existsSync(gitignorePath)) {
+            fs.unlinkSync(gitignorePath);
+        }
+
+        const patterns = await IgnorePatternUtils.getExcludePatterns(testWorkspaceDir);
+        
+        // Check some default patterns
+        assert.ok(patterns.includes('**/node_modules/**'));
+        assert.ok(patterns.includes('**/dist/**'));
+        assert.ok(patterns.includes('**/*.spec.ts'));
+        assert.ok(patterns.includes('**/coverage/**'));
+        assert.ok(patterns.length > 10, 'Should have many default patterns');
+    });
+
+    test('Should handle directory patterns correctly', async () => {
+        // Reset VSCode settings
+        const config = vscode.workspace.getConfiguration('depGraph');
+        await config.update('exclude', undefined, vscode.ConfigurationTarget.Workspace);
+
+        // Create .depgraphignore with various patterns
+        const depgraphIgnorePath = path.join(testWorkspaceDir, '.depgraphignore');
+        const content = `
+# Directory with trailing slash
+coverage/
+# Directory without trailing slash
+dist
+# Nested directory
+src/generated/
+`;
+        fs.writeFileSync(depgraphIgnorePath, content);
+
+        const patterns = await IgnorePatternUtils.getExcludePatterns(testWorkspaceDir);
+        
+        assert.ok(patterns.includes('**/coverage/**'));
+        assert.ok(patterns.includes('**/dist'));
+        assert.ok(patterns.includes('**/src/generated/**'));
+    });
+
+    test('Should handle negation patterns correctly', async () => {
+        // Reset VSCode settings
+        const config = vscode.workspace.getConfiguration('depGraph');
+        await config.update('exclude', undefined, vscode.ConfigurationTarget.Workspace);
+
+        // Create .depgraphignore with negation patterns
+        const depgraphIgnorePath = path.join(testWorkspaceDir, '.depgraphignore');
+        const content = `
+test/**
+!test/unit/**
+*.spec.ts
+!important.spec.ts
+`;
+        fs.writeFileSync(depgraphIgnorePath, content);
+
+        const patterns = await IgnorePatternUtils.getExcludePatterns(testWorkspaceDir);
+        
+        assert.ok(patterns.includes('**/test/**'));
+        assert.ok(!patterns.includes('**/test/unit/**'));
+        assert.ok(patterns.includes('**/*.spec.ts'));
+        assert.ok(!patterns.includes('**/important.spec.ts'));
+    });
+
+    test('Priority should be VSCode settings > .depgraphignore > .gitignore > defaults', async () => {
+        // Create all possible sources
+        const depgraphIgnorePath = path.join(testWorkspaceDir, '.depgraphignore');
+        fs.writeFileSync(depgraphIgnorePath, 'depgraph/**');
+        
+        const gitignorePath = path.join(testWorkspaceDir, '.gitignore');
+        fs.writeFileSync(gitignorePath, 'gitignore/**');
+
+        // Test 1: VSCode settings should take priority
+        const config = vscode.workspace.getConfiguration('depGraph');
+        await config.update('exclude', ['vscode/**'], vscode.ConfigurationTarget.Workspace);
+        
+        let patterns = await IgnorePatternUtils.getExcludePatterns(testWorkspaceDir);
+        assert.deepStrictEqual(patterns, ['vscode/**']);
+
+        // Test 2: .depgraphignore should be used when VSCode settings are empty
+        await config.update('exclude', undefined, vscode.ConfigurationTarget.Workspace);
+        patterns = await IgnorePatternUtils.getExcludePatterns(testWorkspaceDir);
+        assert.ok(patterns.includes('**/depgraph/**'));
+        assert.ok(!patterns.includes('**/gitignore/**'));
+
+        // Test 3: .gitignore should be used when .depgraphignore doesn't exist
+        fs.unlinkSync(depgraphIgnorePath);
+        patterns = await IgnorePatternUtils.getExcludePatterns(testWorkspaceDir);
+        assert.ok(patterns.includes('**/gitignore/**'));
+
+        // Test 4: defaults should be used when nothing else exists
+        fs.unlinkSync(gitignorePath);
+        patterns = await IgnorePatternUtils.getExcludePatterns(testWorkspaceDir);
+        assert.ok(patterns.includes('**/node_modules/**'));
+        assert.ok(patterns.includes('**/dist/**'));
+    });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,9 @@
   },
   "exclude": [
     "test-samples/**",
+    "test-example/**",
+    "test-workspace/**",
+    "test-workspace-*/**",
     "out/**",
     "node_modules/**"
   ]


### PR DESCRIPTION
Closes #15

## Summary
- `.depgraphignore` ファイルによる除外パターン設定機能を実装
- VSCode設定による除外パターンのオーバーライド機能を追加
- 優先順位に基づくフォールバック機構を実装（VSCode設定 > .depgraphignore > .gitignore > デフォルト）

## Test plan
- [x] VSCode設定による除外パターン設定が動作することを確認
- [x] .depgraphignore ファイルの解析が正常に動作することを確認  
- [x] .gitignore フォールバック機能が動作することを確認
- [x] パターン優先順位が正しく動作することを確認
- [x] ネゲーションパターン（\!pattern）が正しく処理されることを確認
- [x] TypeScriptコンパイルが成功することを確認
- [x] ESLintが通過することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for excluding files and directories from the dependency graph using a new `.depgraphignore` file and a configurable setting.
  - Users can now specify custom exclusion patterns via workspace settings for more control over dependency graph results.
  - Expanded TypeScript compiler exclusions to cover additional test-related directories.

- **Bug Fixes**
  - Improved handling of file exclusion by prioritizing user settings, `.depgraphignore`, `.gitignore`, and default patterns.

- **Tests**
  - Added comprehensive tests to verify correct exclusion of files based on ignore patterns and configuration priorities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->