### PR TITLE
fix: ファイル依存グラフの検索機能フリーズを修正

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@types/glob": "^8.1.0",
         "@types/mocha": "^10.0.10",
         "@types/node": "16.x",
+        "@types/sinon": "^17.0.4",
         "@types/vscode": "^1.74.0",
         "@typescript-eslint/eslint-plugin": "^5.45.0",
         "@typescript-eslint/parser": "^5.45.0",
@@ -26,6 +27,7 @@
         "eslint": "^8.28.0",
         "glob": "^11.0.2",
         "mocha": "^11.5.0",
+        "sinon": "^21.0.0",
         "typescript": "^4.9.3"
       },
       "engines": {
@@ -266,6 +268,48 @@
         "node": ">=14"
       }
     },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.5.tgz",
+      "integrity": "sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/@sinonjs/samsam": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.2.tgz",
+      "integrity": "sha512-v46t/fwnhejRSFTGqbpn9u+LQ9xJDse10gNnPgAcxgdoCDMXj/G2asWAC/8Qs+BAZDicX+MNZouXT1A7c83kVw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.1.0"
+      }
+    },
+    "node_modules/@sinonjs/samsam/node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/@ts-morph/common": {
       "version": "0.20.0",
       "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.20.0.tgz",
@@ -351,6 +395,23 @@
       "version": "7.7.0",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.0.tgz",
       "integrity": "sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/sinon": {
+      "version": "17.0.4",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-17.0.4.tgz",
+      "integrity": "sha512-RHnIrhfPO3+tJT0s7cFaXGZvsL4bbR3/k7z3P312qMS4JaS2Tk+KiwiLx1S0rQ56ERj00u1/BtdyVd0FY+Pdew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "node_modules/@types/sinonjs__fake-timers": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
+      "integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1887,6 +1948,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -2742,6 +2811,24 @@
         "url": "https://github.com/steveukx/git-js?sponsor=1"
       }
     },
+    "node_modules/sinon": {
+      "version": "21.0.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-21.0.0.tgz",
+      "integrity": "sha512-TOgRcwFPbfGtpqvZw+hyqJDvqfapr1qUlOizROIk4bBLjlsjlB00Pg6wMFXNtJRpu+eCZuVOaLatG7M8105kAw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "^13.0.5",
+        "@sinonjs/samsam": "^8.0.1",
+        "diff": "^7.0.0",
+        "supports-color": "^7.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -2959,6 +3046,16 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/type-fest": {

--- a/package.json
+++ b/package.json
@@ -173,6 +173,7 @@
     "@types/glob": "^8.1.0",
     "@types/mocha": "^10.0.10",
     "@types/node": "16.x",
+    "@types/sinon": "^17.0.4",
     "@types/vscode": "^1.74.0",
     "@typescript-eslint/eslint-plugin": "^5.45.0",
     "@typescript-eslint/parser": "^5.45.0",
@@ -180,6 +181,7 @@
     "eslint": "^8.28.0",
     "glob": "^11.0.2",
     "mocha": "^11.5.0",
+    "sinon": "^21.0.0",
     "typescript": "^4.9.3"
   }
 }

--- a/src/test/suite/dependencyGraphWebview.test.ts
+++ b/src/test/suite/dependencyGraphWebview.test.ts
@@ -1,0 +1,158 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import * as sinon from 'sinon';
+import { DependencyGraphWebview } from '../../dependencyGraphWebview';
+
+suite('DependencyGraphWebview Test Suite', () => {
+    let context: vscode.ExtensionContext;
+    let webview: DependencyGraphWebview;
+    let sandbox: sinon.SinonSandbox;
+    let webviewPanel: vscode.WebviewPanel;
+    let postMessageStub: sinon.SinonStub;
+
+    setup(() => {
+        sandbox = sinon.createSandbox();
+        
+        // Mock WebviewPanel
+        postMessageStub = sandbox.stub();
+        webviewPanel = {
+            webview: {
+                html: '',
+                postMessage: postMessageStub,
+                onDidReceiveMessage: sandbox.stub()
+            },
+            reveal: sandbox.stub(),
+            onDidDispose: sandbox.stub()
+        } as any;
+
+        // Mock vscode.window.createWebviewPanel
+        sandbox.stub(vscode.window, 'createWebviewPanel').returns(webviewPanel);
+
+        // Mock extension context
+        context = {
+            subscriptions: [],
+            workspaceState: {
+                get: sandbox.stub().returns(''),
+                update: sandbox.stub().returns(Promise.resolve())
+            }
+        } as any;
+
+        webview = new DependencyGraphWebview(context);
+    });
+
+    teardown(() => {
+        sandbox.restore();
+    });
+
+    test('Should create webview panel on show', async () => {
+        await webview.show();
+        
+        assert.ok((vscode.window.createWebviewPanel as sinon.SinonStub).calledOnce);
+        assert.ok((vscode.window.createWebviewPanel as sinon.SinonStub).calledWith(
+            'dependencyGraph',
+            'ファイル依存グラフ',
+            vscode.ViewColumn.One,
+            {
+                enableScripts: true,
+                retainContextWhenHidden: true
+            }
+        ));
+    });
+
+    test('Should reveal existing panel if already shown', async () => {
+        // First show
+        await webview.show();
+        
+        // Second show
+        await webview.show();
+        
+        assert.ok((webviewPanel.reveal as sinon.SinonStub).calledOnce);
+        assert.strictEqual((vscode.window.createWebviewPanel as sinon.SinonStub).callCount, 1);
+    });
+
+    test('Should handle concurrent filter updates correctly', async () => {
+        await webview.show();
+        
+        // Get the message handler
+        const onDidReceiveMessage = (webviewPanel.webview.onDidReceiveMessage as sinon.SinonStub);
+        const messageHandler = onDidReceiveMessage.getCall(0).args[0];
+
+        // Simulate concurrent filter updates
+        const promise1 = messageHandler({ command: 'applyFilter', filterPattern: 'test1' });
+        const promise2 = messageHandler({ command: 'applyFilter', filterPattern: 'test2' });
+
+        await Promise.all([promise1, promise2]);
+
+        // Should send hideLoading message for the blocked request
+        const hideLoadingCalls = postMessageStub.getCalls().filter(call => 
+            call.args[0].command === 'hideLoading'
+        );
+        assert.ok(hideLoadingCalls.length >= 1, 'Should send hideLoading message for blocked requests');
+    });
+
+    test('Should save filter pattern to workspace state', async () => {
+        await webview.show();
+        
+        const onDidReceiveMessage = (webviewPanel.webview.onDidReceiveMessage as sinon.SinonStub);
+        const messageHandler = onDidReceiveMessage.getCall(0).args[0];
+
+        await messageHandler({ command: 'applyFilter', filterPattern: 'src/**/*.ts' });
+
+        assert.ok((context.workspaceState.update as sinon.SinonStub).calledWith(
+            'dependencyGraphFilter',
+            'src/**/*.ts'
+        ));
+    });
+
+    test('Should load saved filter pattern on initialization', async () => {
+        (context.workspaceState.get as sinon.SinonStub).returns('saved-filter');
+        
+        const newWebview = new DependencyGraphWebview(context);
+        await newWebview.show();
+
+        // Check that the saved filter is included in the HTML
+        assert.ok(webviewPanel.webview.html.includes('saved-filter'));
+    });
+
+    test('Should handle errors gracefully', async () => {
+        await webview.show();
+        
+        // Mock analyzer to throw error
+        const analyzerStub = sandbox.stub().rejects(new Error('Test error'));
+        (webview as any).analyzer = { analyzeWorkspace: analyzerStub };
+
+        const showErrorMessageStub = sandbox.stub(vscode.window, 'showErrorMessage');
+
+        const onDidReceiveMessage = (webviewPanel.webview.onDidReceiveMessage as sinon.SinonStub);
+        const messageHandler = onDidReceiveMessage.getCall(0).args[0];
+
+        await messageHandler({ command: 'refresh' });
+
+        assert.ok(showErrorMessageStub.calledOnce);
+        assert.ok(showErrorMessageStub.calledWith('依存グラフの生成に失敗しました: Error: Test error'));
+        
+        // Should send hideLoading message on error
+        const hideLoadingCalls = postMessageStub.getCalls().filter(call => 
+            call.args[0].command === 'hideLoading'
+        );
+        assert.ok(hideLoadingCalls.length >= 1, 'Should send hideLoading message on error');
+    });
+
+    test('Should include proper debounce delay in HTML', async () => {
+        await webview.show();
+        
+        // Check that the HTML contains the increased debounce delay
+        assert.ok(webviewPanel.webview.html.includes('setTimeout(applyFilter, 1000)'));
+        assert.ok(!webviewPanel.webview.html.includes('setTimeout(applyFilter, 300)'));
+    });
+
+    test('Should include loading state management in HTML', async () => {
+        await webview.show();
+        
+        // Check that the HTML contains the loading state management code
+        assert.ok(webviewPanel.webview.html.includes('let isFiltering = false;'));
+        assert.ok(webviewPanel.webview.html.includes('if (isFiltering)'));
+        assert.ok(webviewPanel.webview.html.includes('isFiltering = true;'));
+        assert.ok(webviewPanel.webview.html.includes('case \'hideLoading\':'));
+    });
+});


### PR DESCRIPTION
Closes #21

## Summary
- ファイル依存グラフの検索入力欄に文字を入力した際に画面がフリーズする問題を修正
- debounce時間を300msから1000msに増加し、負荷を軽減
- 同時実行防止のロジックを追加し、複数のフィルタリング処理が同時に実行されないように改善

## Test plan
- [x] 検索入力欄に文字を入力してもフリーズしないことを確認
- [x] フィルタ適用中は「フィルタを適用中...」のローディング表示が出ることを確認
- [x] エラー発生時にもローディング表示が適切に非表示になることを確認
- [x] webviewのユニットテストを追加

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved stability of the dependency graph view by preventing overlapping refresh and filter operations.
  - Loading indicator now accurately reflects the current state during updates and filtering.

- **Bug Fixes**
  - Resolved issues with concurrent updates causing inconsistent UI behavior in the dependency graph view.

- **Tests**
  - Added comprehensive tests for the dependency graph view, covering initialization, concurrency handling, error management, and UI feedback.

- **Chores**
  - Added Sinon and its type definitions as development dependencies for enhanced testing capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->