### PR TITLE
fix: 依存グラフ生成時のアクセス権限エラーを修正

### DIFF
--- a/src/test/suite/dependencyGraphAnalyzerPermission.test.ts
+++ b/src/test/suite/dependencyGraphAnalyzerPermission.test.ts
@@ -1,0 +1,90 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import * as sinon from 'sinon';
+import { DependencyGraphAnalyzer } from '../../dependencyGraphAnalyzer';
+import * as globby from 'globby';
+
+suite('DependencyGraphAnalyzer Permission Error Test Suite', () => {
+    let analyzer: DependencyGraphAnalyzer;
+    let sandbox: sinon.SinonSandbox;
+
+    setup(() => {
+        analyzer = new DependencyGraphAnalyzer();
+        sandbox = sinon.createSandbox();
+    });
+
+    teardown(() => {
+        sandbox.restore();
+    });
+
+    test('Should handle permission errors gracefully', async () => {
+        // Mock globby to throw a permission error
+        const permissionError = new Error("EACCES: permission denied, scandir '/Library/OSAnalytics'");
+        sandbox.stub(globby, 'default').rejects(permissionError);
+
+        // Spy on console.error and vscode.window.showErrorMessage
+        const consoleErrorSpy = sandbox.spy(console, 'error');
+        const showErrorMessageSpy = sandbox.spy(vscode.window, 'showErrorMessage');
+
+        // Analyze workspace should not throw but return empty graph
+        const graph = await analyzer.analyzeWorkspace();
+
+        // Verify error was logged
+        assert.ok(consoleErrorSpy.calledOnce, 'console.error should be called once');
+        assert.ok(consoleErrorSpy.firstCall.args[0].includes('Error collecting files'), 
+            'console.error should log the correct message');
+
+        // Verify user-friendly error message was shown
+        assert.ok(showErrorMessageSpy.calledOnce, 'vscode.window.showErrorMessage should be called once');
+        assert.ok(showErrorMessageSpy.firstCall.args[0].includes('依存グラフの生成中にアクセス権限エラーが発生しました'), 
+            'Error message should be shown to user');
+
+        // Verify empty graph is returned
+        assert.strictEqual(graph.nodes.length, 0, 'Graph should have no nodes');
+        assert.strictEqual(graph.edges.length, 0, 'Graph should have no edges');
+    });
+
+    test('Should not follow symbolic links', async () => {
+        // Create a spy on globby to check the options
+        const globbySpy = sandbox.spy(globby, 'default');
+
+        // Analyze workspace
+        await analyzer.analyzeWorkspace();
+
+        // Verify globby was called with correct options
+        assert.ok(globbySpy.calledOnce, 'globby should be called once');
+        const options = globbySpy.firstCall.args[1] as any;
+        assert.ok(options, 'Options should be provided to globby');
+        assert.strictEqual(options.followSymbolicLinks, false, 
+            'followSymbolicLinks should be false to prevent scanning outside workspace');
+        assert.strictEqual(options.onlyFiles, true, 
+            'onlyFiles should be true to only scan files');
+        assert.strictEqual(options.dot, false, 
+            'dot should be false to exclude hidden files by default');
+        assert.strictEqual(options.unique, true, 
+            'unique should be true to ensure unique results');
+    });
+
+    test('Should remove absolute paths from filter patterns', async () => {
+        // Create a spy on globby to check the patterns
+        const globbySpy = sandbox.spy(globby, 'default');
+
+        // Analyze workspace with absolute path filter
+        await analyzer.analyzeWorkspace('/src');
+
+        // Verify globby was called with relative patterns
+        assert.ok(globbySpy.calledOnce, 'globby should be called once');
+        const patterns = globbySpy.firstCall.args[0] as string[];
+        assert.ok(Array.isArray(patterns), 'Patterns should be an array');
+        
+        // All patterns should be relative (not start with /)
+        patterns.forEach((pattern: string) => {
+            assert.ok(!pattern.startsWith('/'), 
+                `Pattern "${pattern}" should not start with / to stay within workspace`);
+        });
+
+        // Should have patterns for src directory
+        assert.ok(patterns.some((p: string) => p.includes('src/**/*.ts')), 
+            'Should include TypeScript files in src directory');
+    });
+});


### PR DESCRIPTION
Closes #23

## Summary
- 依存グラフ生成時に発生していた「Error: EACCES: permission denied, scandir '/Library/OSAnalytics'」エラーを修正しました
- globbyの設定を改善し、ワークスペース外のディレクトリをスキャンしないようにしました

## Changes
- `followSymbolicLinks: false` - シンボリックリンクを辿らないように設定
- `onlyFiles: true` - ファイルのみをスキャン対象に限定
- `dot: false` - 隠しファイルをデフォルトで除外
- `unique: true` - 重複結果を防止
- フィルターパターンから絶対パスプレフィックスを削除する処理を追加
- アクセス権限エラーを適切にキャッチし、ユーザーフレンドリーなエラーメッセージを表示
- エラー発生時も部分的な結果で処理を継続できるように改善

## Test plan
- [x] 依存グラフ生成が正常に動作することを確認
- [x] アクセス権限エラーが発生しないことを確認
- [x] ユニットテストを追加し、エラーハンドリングが適切に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling during file scanning to display user-friendly messages for permission errors and ensure continued analysis without interruption.

- **Tests**
  - Added new tests to verify correct handling of permission errors, symbolic link scanning options, and filter pattern normalization in file analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->