### PR TITLE
fix: 拡張機能のアクティベーションエラーを修正

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,74 @@
+# VSCode拡張機能の開発・実行方法
+
+## 拡張機能の実行手順
+
+### 1. 依存関係のインストール
+```bash
+npm install
+```
+
+### 2. TypeScriptのコンパイル
+```bash
+npm run compile
+```
+
+### 3. 拡張機能の実行
+1. VSCodeでこのプロジェクトフォルダを開く
+2. **F5**キーを押す（または「実行」→「デバッグの開始」）
+3. 新しいVSCodeウィンドウ（Extension Development Host）が開く
+4. この新しいウィンドウで拡張機能が利用可能
+
+## コマンドの実行方法
+
+Extension Development Hostウィンドウで：
+- **Ctrl+Shift+P**（Mac: **Cmd+Shift+P**）でコマンドパレットを開く
+- `Layered Generator`と入力してコマンドを検索
+
+## 利用可能なコマンド
+
+| コマンド | 説明 |
+|---------|------|
+| `Layered Generator: テンプレートからファイル生成` | レイヤードアーキテクチャのファイルを生成 |
+| `Layered Generator: テンプレート設定` | テンプレートの設定を編集 |
+| `Layered Generator: テンプレート登録` | 新しいテンプレートを登録 |
+| `Layered Generator: Protobufフィールドに連番を付ける` | .protoファイルのフィールドに番号を自動付与 |
+| `Layered Generator: ファイル依存グラフを表示` | プロジェクトの依存関係グラフを表示 |
+| `Layered Generator: GraphQLスキーマドキュメント生成` | GraphQLスキーマからMarkdownドキュメントを生成 |
+| `Layered Generator: Generate Test Skeletons` | APIテストのスケルトンを生成 |
+
+## トラブルシューティング
+
+### "command 'layered-gen.xxx' not found"エラーが出る場合
+
+1. **コンパイルを確認**
+   ```bash
+   npm run compile
+   ```
+
+2. **VSCodeを再起動**
+   - Extension Development Hostウィンドウを閉じる
+   - F5で再度起動
+
+3. **拡張機能の出力を確認**
+   - Extension Development Hostウィンドウで
+   - 「表示」→「出力」を開く
+   - ドロップダウンから「拡張機能ホスト」を選択
+   - エラーメッセージを確認
+
+4. **開発者ツールでエラーを確認**
+   - Extension Development Hostウィンドウで
+   - 「ヘルプ」→「開発者ツールの切り替え」
+   - コンソールタブでエラーを確認
+
+### 拡張機能が有効にならない場合
+
+1. `package.json`の`activationEvents`を確認
+   - 現在は`onStartupFinished`で起動時に自動的に有効化
+
+2. 拡張機能の出力ログで"Layered Architecture Generator is now active!"が表示されているか確認
+
+## 開発時の注意事項
+
+- TypeScriptファイルを変更した後は必ず`npm run compile`を実行
+- または`npm run watch`でファイル変更を自動的にコンパイル
+- Extension Development Hostウィンドウは変更後に再起動（Ctrl+R）で更新可能

--- a/src/dependencyGraphAnalyzer.ts
+++ b/src/dependencyGraphAnalyzer.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import globby from 'globby';
-import { Project, SourceFile, SyntaxKind } from 'ts-morph';
+import { Project, SourceFile, SyntaxKind, ts } from 'ts-morph';
 import * as path from 'path';
 import { IgnorePatternUtils } from './ignorePatternUtils';
 
@@ -21,9 +21,18 @@ export class DependencyGraphAnalyzer {
     private workspaceRoot: string;
 
     constructor() {
-        this.project = new Project();
         this.workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || '';
         console.log('DependencyGraphAnalyzer initialized with workspaceRoot:', this.workspaceRoot);
+        
+        // Initialize ts-morph Project with proper configuration
+        this.project = new Project({
+            // Don't specify tsConfigFilePath to avoid searching for it
+            skipAddingFilesFromTsConfig: true,
+            compilerOptions: {
+                allowJs: true,
+                jsx: ts.JsxEmit.React
+            }
+        });
     }
 
     async analyzeWorkspace(filterPattern?: string): Promise<DependencyGraph> {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,15 +8,16 @@ import { GraphQLDocsGenerator } from './graphqlDocsGenerator';
 import { ApiTestSkeletonGenerator } from './apiTestSkeletonGenerator';
 
 export function activate(context: vscode.ExtensionContext) {
-    console.log('Layered Architecture Generator is now active!');
+    try {
+        console.log('Layered Architecture Generator is now active!');
 
-    const templateManager = new TemplateManager();
-    const templateEditorProvider = new TemplateEditorProvider(context, templateManager);
-    const protobufFieldNumberer = new ProtobufFieldNumberer();
-    const dependencyTreeProvider = new DependencyTreeProvider();
-    const dependencyGraphWebview = new DependencyGraphWebview(context);
-    const graphqlDocsGenerator = new GraphQLDocsGenerator();
-    const apiTestSkeletonGenerator = new ApiTestSkeletonGenerator();
+        const templateManager = new TemplateManager();
+        const templateEditorProvider = new TemplateEditorProvider(context, templateManager);
+        const protobufFieldNumberer = new ProtobufFieldNumberer();
+        const dependencyTreeProvider = new DependencyTreeProvider();
+        const dependencyGraphWebview = new DependencyGraphWebview(context);
+        const graphqlDocsGenerator = new GraphQLDocsGenerator();
+        const apiTestSkeletonGenerator = new ApiTestSkeletonGenerator();
 
     let disposable = vscode.commands.registerCommand('layered-gen.generateFiles', async (uri: vscode.Uri) => {
         if (!uri) {
@@ -257,6 +258,10 @@ export function activate(context: vscode.ExtensionContext) {
         }
     });
     context.subscriptions.push(generateApiTestSkeletonsCommand);
+    } catch (error) {
+        console.error('Failed to activate extension:', error);
+        vscode.window.showErrorMessage(`拡張機能のアクティベーションに失敗しました: ${error}`);
+    }
 }
 
 export function deactivate() {

--- a/src/graphqlAnalyzer.ts
+++ b/src/graphqlAnalyzer.ts
@@ -1,4 +1,4 @@
-import { Project, SourceFile, Decorator, MethodDeclaration, ClassDeclaration } from 'ts-morph';
+import { Project, SourceFile, Decorator, MethodDeclaration, ClassDeclaration, ts } from 'ts-morph';
 import * as path from 'path';
 import * as fs from 'fs';
 import { parse, DocumentNode, OperationDefinitionNode, FieldDefinitionNode, TypeNode, DefinitionNode } from 'graphql';
@@ -19,9 +19,13 @@ export class GraphQLAnalyzer {
     private project: Project;
 
     constructor() {
+        // Initialize ts-morph Project without specifying tsconfig path
         this.project = new Project({
-            tsConfigFilePath: path.join(process.cwd(), 'tsconfig.json'),
-            skipAddingFilesFromTsConfig: true
+            skipAddingFilesFromTsConfig: true,
+            compilerOptions: {
+                allowJs: true,
+                jsx: ts.JsxEmit.React
+            }
         });
     }
 

--- a/src/restApiAnalyzer.ts
+++ b/src/restApiAnalyzer.ts
@@ -1,4 +1,4 @@
-import { Project, SourceFile, Decorator, MethodDeclaration, ClassDeclaration } from 'ts-morph';
+import { Project, SourceFile, Decorator, MethodDeclaration, ClassDeclaration, ts } from 'ts-morph';
 import * as path from 'path';
 
 export interface RestEndpoint {
@@ -18,9 +18,13 @@ export class RestApiAnalyzer {
     private project: Project;
 
     constructor() {
+        // Initialize ts-morph Project without specifying tsconfig path
         this.project = new Project({
-            tsConfigFilePath: path.join(process.cwd(), 'tsconfig.json'),
-            skipAddingFilesFromTsConfig: true
+            skipAddingFilesFromTsConfig: true,
+            compilerOptions: {
+                allowJs: true,
+                jsx: ts.JsxEmit.React
+            }
         });
     }
 


### PR DESCRIPTION
## 概要
拡張機能のアクティベーション時に発生していた「command 'layered-gen.xxx' not found」エラーを修正しました。

## 問題
コンソールに以下のエラーが表示され、拡張機能のコマンドが実行できない状態でした：
```
Error: Activating extension 'sanyama0554.vscode-layered-gen' failed: File not found: /mnt/c/Users/yumay/AppData/Local/Programs/cursor/tsconfig.json
```

## 原因
ts-morphライブラリのProjectインスタンスが、存在しないtsconfig.jsonファイルを探そうとしていたことが原因でした。

## 修正内容
1. **ts-morphの初期化を修正**
   - `DependencyGraphAnalyzer`、`GraphQLAnalyzer`、`RestApiAnalyzer`でProjectインスタンスの初期化方法を変更
   - `skipAddingFilesFromTsConfig: true`を設定
   - tsconfigパスの明示的な指定を削除
   - 適切なコンパイラオプションを設定

2. **エラーハンドリングの改善**
   - extension.tsのactivate関数全体をtry-catchでラップ
   - エラー時にユーザーフレンドリーなメッセージを表示

3. **開発者向けドキュメントの追加**
   - DEVELOPMENT.mdファイルを追加し、拡張機能の実行方法とトラブルシューティング手順を記載

## テスト
- [x] F5で拡張機能を起動し、コマンドが正常に実行できることを確認
- [x] 各コマンドが正しく動作することを確認
- [x] エラーが発生しないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a comprehensive development guide outlining setup, execution, troubleshooting, and best practices for the VSCode extension.

- **Bug Fixes**
  - Improved extension startup reliability by adding global error handling during activation, with user-friendly error messages.

- **Refactor**
  - Updated internal project initialization to use explicit compiler options, enhancing compatibility with JavaScript and React files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->