### PR TITLE
依存グラフ生成をコマンド実行時に限定する

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,6 +149,11 @@
           "items": {
             "type": "string"
           }
+        },
+        "layered-gen.enableAutoGraphGeneration": {
+          "type": "boolean",
+          "default": false,
+          "description": "ファイル変更時に依存グラフを自動的に更新する"
         }
       }
     }

--- a/src/features/dependency-graph/dependencyTreeProvider.ts
+++ b/src/features/dependency-graph/dependencyTreeProvider.ts
@@ -41,16 +41,20 @@ export class DependencyTreeProvider implements vscode.TreeDataProvider<Dependenc
 
     constructor() {
         this.analyzer = new DependencyGraphAnalyzer();
-        this.refresh();
+        // 初期化時の自動リフレッシュを無効化
+        // this.refresh();
     }
 
-    refresh(): void {
-        this.analyzer.analyzeWorkspace().then(graph => {
+    refresh(cancellationToken?: vscode.CancellationToken): Promise<void> {
+        return this.analyzer.analyzeWorkspace(undefined, cancellationToken).then(graph => {
             this.graph = graph;
             this._onDidChangeTreeData.fire();
         }).catch(error => {
-            console.error('Failed to analyze workspace:', error);
-            vscode.window.showErrorMessage(`依存グラフの解析に失敗しました: ${error.message}`);
+            if (error.message !== 'Analysis cancelled') {
+                console.error('Failed to analyze workspace:', error);
+                vscode.window.showErrorMessage(`依存グラフの解析に失敗しました: ${error.message}`);
+            }
+            throw error;
         });
     }
 

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -66,4 +66,26 @@ suite('Extension Test Suite', () => {
         const commands = await vscode.commands.getCommands();
         assert.ok(commands.includes('layered-gen.generateApiTestSkeletons'));
     });
+
+    test('Should have enableAutoGraphGeneration setting default to false', () => {
+        const config = vscode.workspace.getConfiguration('layered-gen');
+        const autoGeneration = config.get('enableAutoGraphGeneration');
+        assert.strictEqual(autoGeneration, false, 'enableAutoGraphGeneration should default to false');
+    });
+
+    test('Should not auto-generate dependency graph on activation', async () => {
+        // 拡張機能を再度アクティベート
+        const extension = vscode.extensions.getExtension('sanyama0554.vscode-layered-gen');
+        if (extension && !extension.isActive) {
+            await extension.activate();
+        }
+        
+        // TreeViewを取得して初期状態を確認
+        // TreeViewは自動的に生成されないため、初期状態では空になるはず
+        // この部分は実際のTreeViewインスタンスにアクセスできないため、
+        // コマンドが正しく登録されていることを確認
+        const commands = await vscode.commands.getCommands();
+        assert.ok(commands.includes('layered-gen.showDependencyGraph'), 'Dependency graph command should be available');
+        assert.ok(commands.includes('layered-gen.refreshDependencyGraph'), 'Refresh command should be available');
+    });
 });

--- a/src/test/suite/features/dependency-graph/dependencyTreeProvider.test.ts
+++ b/src/test/suite/features/dependency-graph/dependencyTreeProvider.test.ts
@@ -17,6 +17,8 @@ suite('DependencyTreeProvider Test Suite', () => {
     test('Should provide tree items', async () => {
         const children = await treeProvider.getChildren();
         assert.ok(Array.isArray(children), 'Should return an array');
+        // 初期化時は空であることを確認（自動リフレッシュが無効化されているため）
+        assert.strictEqual(children.length, 0, 'Should return empty array on initialization');
     });
 
     test('Should handle getTreeItem correctly', () => {
@@ -44,17 +46,34 @@ suite('DependencyTreeProvider Test Suite', () => {
         assert.ok(testItem.iconPath, 'Should have warning icon for cyclic dependencies');
     });
 
-    test('Should refresh tree data', () => {
+    test('Should refresh tree data', async () => {
         let eventFired = false;
         const disposable = treeProvider.onDidChangeTreeData(() => {
             eventFired = true;
         });
 
-        treeProvider.refresh();
-        
-        // Give some time for the async operation
-        setTimeout(() => {
+        try {
+            await treeProvider.refresh();
+            // イベントが発火したことを確認
+            assert.ok(eventFired, 'onDidChangeTreeData event should be fired after refresh');
+        } finally {
             disposable.dispose();
-        }, 1000);
+        }
+    });
+
+    test('Should handle cancellation during refresh', async () => {
+        const cancellationTokenSource = new vscode.CancellationTokenSource();
+        
+        // すぐにキャンセル
+        cancellationTokenSource.cancel();
+        
+        try {
+            await treeProvider.refresh(cancellationTokenSource.token);
+            assert.fail('Should throw error on cancellation');
+        } catch (error: any) {
+            assert.strictEqual(error.message, 'Analysis cancelled', 'Should throw cancellation error');
+        } finally {
+            cancellationTokenSource.dispose();
+        }
     });
 });


### PR DESCRIPTION
Closes #28

## Summary
- 依存グラフの自動生成を無効化し、手動実行のみに変更
- 大規模リポジトリでのパフォーマンス改善
- 進捗表示とキャンセル機能を追加

## Changes
- `layered-gen.enableAutoGraphGeneration`設定を追加（デフォルト: false）
- 拡張機能初期化時の自動グラフ生成を無効化  
- ファイル変更時の自動更新を設定で制御可能に
- `showDependencyGraph`コマンド実行時に進捗表示とキャンセル対応を追加
- `DependencyGraphAnalyzer`にCancellationTokenサポートを追加
- 関連するテストを更新

## Test Plan
- [x] 拡張機能起動時に依存グラフが自動生成されないことを確認
- [x] `showDependencyGraph`コマンド実行時のみグラフが生成されることを確認
- [x] 進捗表示中にキャンセルできることを確認
- [x] `enableAutoGraphGeneration`をtrueに設定するとファイル変更時に自動更新されることを確認
- [x] 既存のテストが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a setting to enable or disable automatic dependency graph updates when files change.
  - Commands for showing and refreshing the dependency graph now display progress and allow cancellation.

- **Bug Fixes**
  - Improved handling of cancellation during dependency analysis, ensuring processes can be stopped promptly.

- **Tests**
  - Added tests for the new configuration setting, cancellation behavior, and event handling during refresh operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->